### PR TITLE
Set default string limit to 191

### DIFF
--- a/lib/Ruckusing/Adapter/MySQL/Base.php
+++ b/lib/Ruckusing/Adapter/MySQL/Base.php
@@ -103,7 +103,7 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
     {
         $types = array(
                 'primary_key'   => array('name' => 'integer', 'limit' => 11, 'null' => false),
-                'string'        => array('name' => "varchar", 'limit' => 255),
+                'string'        => array('name' => "varchar", 'limit' => 191),
                 'text'          => array('name' => "text"),
                 'tinytext'      => array('name' => "tinytext"),
                 'mediumtext'    => array('name' => 'mediumtext'),


### PR DESCRIPTION
This is done to support older versions of MySQL whose default key limit is based on their own 3-byte variation of UTF-8. This causes official 4-byte UTF-8 to have a limit of 191 instead of 255.